### PR TITLE
Fix syntax error in string formatting of GainData class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Changes
 =======
 
+- Fixed string format syntax error in ``__str__`` method of the ``GainData``
+  class which could be thrown in case ``rgain3`` was used as a library.
 - Dropped support for Python 3.5 which reached end-of-life
 - Added support for MP4/iTunes album/artist tags
 - Updated the package structure so that the scripts are located in the `rgain`

--- a/rgain3/lib/__init__.py
+++ b/rgain3/lib/__init__.py
@@ -28,7 +28,6 @@ class GainType(enum.Enum):
 
 
 class GainData:
-
     """A class that contains Replay Gain data.
 
     Arguments for ``__init__`` are also instance variables. These are:
@@ -48,7 +47,7 @@ class GainData:
         self.gain_type = gain_type
 
     def __str__(self):
-        return "gain={.2f} dB; peak={.8f}; reference-level={} dB".format(
+        return "gain={:.2f} dB; peak={:.8f}; reference-level={} dB".format(
             self.gain, self.peak, self.ref_level
         )
 

--- a/test/test_rgain_init.py
+++ b/test/test_rgain_init.py
@@ -4,6 +4,26 @@ from rgain3.lib import GainData, GainType
 
 
 class TestGainData(unittest.TestCase):
+    def test_str(self):
+        self.assertEqual(
+            str(GainData(-1.2)),
+            "gain=-1.20 dB; peak=1.00000000; reference-level=89 dB"
+        )
+        self.assertEqual(
+            str(GainData(-1.2, 0.6, 88, GainType.TP_ALBUM)),
+            "gain=-1.20 dB; peak=0.60000000; reference-level=88 dB"
+        )
+
+    def test_repr(self):
+        self.assertEqual(
+            repr(GainData(-1.2)),
+            "GainData(-1.2, 1.0, 89, GainType.TP_UNDEFINED)",
+        )
+        self.assertEqual(
+            repr(GainData(-1.2, 0.6, 88, GainType.TP_ALBUM)),
+            "GainData(-1.2, 0.6, 88, GainType.TP_ALBUM)",
+        )
+
     def test_eq(self):
         gd1 = GainData(-5, 0.5, 80)
         gd2 = GainData(-5, 0.5, 80)


### PR DESCRIPTION
The `GainData` class should be implemented as `dataclass` in the future, once support for Python 3.6 can be dropped, see #39 