### PR TITLE
Updated readme and man files to address changes in Quod Libet

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,4 +208,4 @@ The manpages were originally written for the Debian project and are::
 [2]: http://mp3gain.sourceforce.net
 [3]: http://wiki.hydrogenaudio.org/index.php?title=ReplayGain_specification#ID3v2
 [4]: http://foobar2000.org
-[5]: http://code.google.com/p/quodlibet
+[5]: https://github.com/quodlibet/quodlibet/

--- a/README.md
+++ b/README.md
@@ -144,15 +144,15 @@ behaviour. Possible choices with this switch are:
 *replaygain.org* (alias: *fb2k*)
   Replay Gain information is stored in ID3v2 TXXX frames. This format is
   specified on the replaygain.org website as the recommended format for MP3
-  files. Notably, this format is also used by the [foobar2000 music player for
-  Windows][4].
+   files. Notably, this format is used by music players like [foobar2000][4] 
+   and [Quod Libet][5]. The latter can also fall back on the legacy format.
 *legacy* (alias: *ql*)
   Replay Gain information is stored in ID3v2.4 RVA2 frames. This format is
-  described as "legacy" by replaygain.org; however, it is still the primary
-  format for at least the [Quod Libet music player][5] and possibly others. It
-  should be noted that this format does not support volume adjustments of more
-  than 64 dB: if the calculated gain value is smaller than -64 dB or greater
-  than or equal to +64 dB, it is clamped to these limit values.
+   described as "legacy" by replaygain.org; however, it might still be the
+   primary format for some music players. It should be noted that this format
+   does not support volume adjustments of more than 64 dB: if the calculated
+   gain value is smaller than -64 dB or greater than or equal to +64 dB, it is
+   clamped to these limit values.
 *default*
   This is the default implementation used by both **replaygain** and
   **collectiongain**. When writing Replay Gain data, both the *replaygain.org*

--- a/man/collectiongain.rst
+++ b/man/collectiongain.rst
@@ -83,11 +83,11 @@ behaviour. Possible choices with this switch are:
 
  - *legacy* (alias: *ql*)
    Replay Gain information is stored in ID3v2.4 RVA2 frames. This format is
-   described as "legacy" by replaygain.org; however, it might still be the primary
-   format for some music players. It should be noted that this format does not 
-   support volume adjustments of more than 64 dB: if the calculated gain value is 
-   smaller than -64 dB or greater than or equal to +64 dB, it is clamped to these 
-   limit values.
+   described as "legacy" by replaygain.org; however, it might still be the
+   primary format for some music players. It should be noted that this format
+   does not support volume adjustments of more than 64 dB: if the calculated
+   gain value is smaller than -64 dB or greater than or equal to +64 dB, it is
+   clamped to these limit values.
 
  - *default*
    This is the default implementation used by both **replaygain** and

--- a/man/collectiongain.rst
+++ b/man/collectiongain.rst
@@ -83,11 +83,11 @@ behaviour. Possible choices with this switch are:
 
  - *legacy* (alias: *ql*)
    Replay Gain information is stored in ID3v2.4 RVA2 frames. This format is
-   described as "legacy" by replaygain.org; however, it is still the primary
-   format for at least the Quod Libet music player [4] and possibly others. It
-   should be noted that this format does not support volume adjustments of more
-   than 64 dB: if the calculated gain value is smaller than -64 dB or greater
-   than or equal to +64 dB, it is clamped to these limit values.
+   described as "legacy" by replaygain.org; however, it might still be the primary
+   format for some music players. It should be noted that this format does not 
+   support volume adjustments of more than 64 dB: if the calculated gain value is 
+   smaller than -64 dB or greater than or equal to +64 dB, it is clamped to these 
+   limit values.
 
  - *default*
    This is the default implementation used by both **replaygain** and
@@ -104,7 +104,7 @@ behaviour. Possible choices with this switch are:
 
 [3] http://foobar2000.org
 
-[4] http://code.google.com/p/quodlibet
+[4] https://github.com/quodlibet/quodlibet
 
 SEE ALSO
 ========

--- a/man/replaygain.rst
+++ b/man/replaygain.rst
@@ -81,11 +81,11 @@ behaviour. Possible choices with this switch are:
 
  - *legacy* (alias: *ql*)
    Replay Gain information is stored in ID3v2.4 RVA2 frames. This format is
-   described as "legacy" by replaygain.org; however, it is still the primary
-   format for at least the Quod Libet music player [4] and possibly others. It
-   should be noted that this format does not support volume adjustments of more
-   than 64 dB: if the calculated gain value is smaller than -64 dB or greater
-   than or equal to +64 dB, it is clamped to these limit values.
+   described as "legacy" by replaygain.org; however, it might still be the
+   primary format for some music players. It should be noted that this format
+   does not support volume adjustments of more than 64 dB: if the calculated
+   gain value is smaller than -64 dB or greater than or equal to +64 dB, it is
+   clamped to these limit values.
 
  - *default*
    This is the default implementation used by both **replaygain** and
@@ -102,7 +102,7 @@ behaviour. Possible choices with this switch are:
 
 [3] http://foobar2000.org
 
-[4] http://code.google.com/p/quodlibet
+[4] https://github.com/quodlibet/quodlibet
 
 SEE ALSO
 ========

--- a/man/replaygain.rst
+++ b/man/replaygain.rst
@@ -76,8 +76,8 @@ behaviour. Possible choices with this switch are:
  - *replaygain.org* (alias: *fb2k*)
    Replay Gain information is stored in ID3v2 TXXX frames. This format is
    specified on the replaygain.org website as the recommended format for MP3
-   files. Notably, this format is also used by the foobar2000 music player for
-   Windows [3].
+   files. Notably, this format is used by music players like foobar2000 [3] 
+   and Quod Libet [4], which can also fall back on the legacy format).
 
  - *legacy* (alias: *ql*)
    Replay Gain information is stored in ID3v2.4 RVA2 frames. This format is

--- a/man/replaygain.rst
+++ b/man/replaygain.rst
@@ -77,7 +77,7 @@ behaviour. Possible choices with this switch are:
    Replay Gain information is stored in ID3v2 TXXX frames. This format is
    specified on the replaygain.org website as the recommended format for MP3
    files. Notably, this format is used by music players like foobar2000 [3] 
-   and Quod Libet [4], which can also fall back on the legacy format).
+   and Quod Libet [4]. The latter can also fall back on the legacy format.
 
  - *legacy* (alias: *ql*)
    Replay Gain information is stored in ID3v2.4 RVA2 frames. This format is


### PR DESCRIPTION
Quod Libet switched 2015 to preferring the recommended format over the legacy one:

https://github.com/quodlibet/quodlibet/issues/1587

(and the repository location changed)

If you merge this, please squash the changes (github merge dropdown) to something like "Updated readme and man files to address changes in Quod Libet"