### PR TITLE
rgio: Add "opus" to base formats map

### DIFF
--- a/rgain3/lib/rgio.py
+++ b/rgain3/lib/rgio.py
@@ -336,6 +336,7 @@ class BaseFormatsMap:
     BASE_MAP = {
         "ogg": _simplereaderwriter,
         "oga": _simplereaderwriter,
+        "opus": _simplereaderwriter,
         "flac": _simplereaderwriter,
         "wv": _simplereaderwriter,
         "m4a": _mp4readerwriter,


### PR DESCRIPTION
This isn't strictly necessary thanks to #22, but .opus is the officially
recommended extension for Opus streams in Ogg containers, so
it may be worth having it in the map anyway.