### PR TITLE
Change tests.sh for portability

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -xe
+#!/bin/sh -xe
 
 pip install -e .
 pytest -vvv -s --cache-clear
-find . -name __pycache__ -type d | xargs rm -rf
+find . -name __pycache__ -type d -exec rm -rf {} +
 rm -rf .pytest_cache/ .mypy_cache/ rgain.egg-info/


### PR DESCRIPTION
1) Changed to use /bin/sh instead of /bin/bash

Everything in the script is already posix compliant.

2) Change to use find -exec rm -rf {} +  instead of find | xargs rm -rf

This avoids the edge case of when one of the paths to the subdirectories have spaces or other unusual characters.

An alternative fix for that is to use "find . -name __pycache__ -type d -print0 | xargs -0 rm -rf", but this is a less portable option