### PR TITLE
chore: Add support for newer Python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          # - "3.8"
-          # - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -34,12 +32,12 @@ jobs:
           sudo apt-get install -y gir1.2-gstreamer-1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly libcairo2-dev libgirepository-2.0-dev
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           python -m pip install -e ".[test]"
           python -m pip install coveralls
       - name: Run tests
         run: |
-          python -m pytest -v
+          python -m pytest
       - name: Test source distribution
         run: |
           rm -fr dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,13 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 3.6
-        - 3.7
-        - 3.8
-        - 3.9
+          # - "3.8"
+          # - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -28,7 +31,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y gir1.2-gstreamer-1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly libcairo2-dev libgirepository1.0-dev
+          sudo apt-get install -y gir1.2-gstreamer-1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly libcairo2-dev libgirepository-2.0-dev
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -36,7 +39,7 @@ jobs:
           python -m pip install coveralls
       - name: Run tests
         run: |
-          python -m pytest
+          python -m pytest -v
       - name: Test source distribution
         run: |
           rm -fr dist

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,22 @@
 Changes
 =======
 
+- Fixed `--version` (#57)
+- Fixed broken import `pkg_resources` when project is built with a setuptools version newer than 82.0
 - Fixed string format syntax error in ``__str__`` method of the ``GainData``
   class which could be thrown in case ``rgain3`` was used as a library.
-- Dropped support for Python 3.5 which reached end-of-life
+- Dropped support for Python 3.5, 3.6, and 3.7 which reached end-of-life
 - Added support for MP4/iTunes album/artist tags
 - Updated the package structure so that the scripts are located in the `rgain`
   module. This means that they can now also be invoked using `python -m
   rgain3.replaygain` and `python -m rgain3.collectiongain`.
 - Added file type guessing based on magic numbers signature
+
+rgain3 1.1.1 (2021-07-23)
+-------------------------
+
+- Always convert tag values to strings, which fixes a `TypeError` when mutagen returns `bytes`
+  values from audio metadata fields. (#38)
 
 rgain3 1.1.0 (2020-11-12)
 -------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Changes
 - Fixed broken import `pkg_resources` when project is built with a setuptools version newer than 82.0
 - Fixed string format syntax error in ``__str__`` method of the ``GainData``
   class which could be thrown in case ``rgain3`` was used as a library.
-- Dropped support for Python 3.5, 3.6, and 3.7 which reached end-of-life
+- Dropped support for Python 3.5, 3.6, 3.7, 3.8, and 3.9 which reached end-of-life
 - Added support for MP4/iTunes album/artist tags
 - Updated the package structure so that the scripts are located in the `rgain`
   module. This means that they can now also be invoked using `python -m

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,6 @@ include MANIFEST.in
 include man/*
 include requirements.txt
 include test-requirements.txt
-include test/data/*.flac
-include test/data/*.mp3
+include test/data/*
 include tests.sh
 include tox.ini

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _This is a Python 3 fork of Felix Krull's `rgain` repository on Bitbucket._
 
 ## Requirements
 
-- Python >= 3.6 -- http://python.org/
+- Python >= 3.8 -- http://python.org/
 - GStreamer -- http://gstreamer.org/
 - PyGObject -- https://pygobject.readthedocs.io/en/latest/
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _This is a Python 3 fork of Felix Krull's `rgain` repository on Bitbucket._
 
 ## Requirements
 
-- Python >= 3.8 -- http://python.org/
+- Python >= 3.10 -- http://python.org/
 - GStreamer -- http://gstreamer.org/
 - PyGObject -- https://pygobject.readthedocs.io/en/latest/
 
@@ -38,7 +38,7 @@ $ apt install \
 ```
 
 (Or if you prefer to install the latest PyGObject from source code,
-replace `python3-gi` with `libcairo2-dev libgirepository1.0-dev`.)
+replace `python3-gi` with `libcairo2-dev libgirepository-2.0-dev`.)
 
 You will also need GStreamer decoding plugins for any audio formats you want to
 use.

--- a/rgain3/lib/util.py
+++ b/rgain3/lib/util.py
@@ -74,8 +74,8 @@ def getfilesystemencoding():
 
 @contextlib.contextmanager
 def gobject_signals(obj, *signals):
-    """Context manager to connect and disconnect GObject signals using a ``with``
-    statement.
+    """Context manager to connect and disconnect GObject signals using a
+    ``with`` statement.
     """
     signal_ids = []
     try:

--- a/rgain3/lib/version.py
+++ b/rgain3/lib/version.py
@@ -14,10 +14,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version
 
-try:
-    __version__ = get_distribution("rgain").version
-except DistributionNotFound:
-    # rgain package is not installed
-    __version__ = None
+__version__ = version("rgain3")

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ class Version(tuple):
 
 
 # a version must be PEP 440 compliant
-__version__ = Version(1, 0, 0)
+__version__ = Version(1, 1, 1)
 
 
 def requirements(filename: str) -> List[str]:

--- a/setup.py
+++ b/setup.py
@@ -145,8 +145,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -169,7 +167,7 @@ setup(
     extras_require={
         "test": ["tox>=3.14,<4.0"] + requirements("test-requirements.txt")
     },
-    python_requires=">=3.8",
+    python_requires=">=3.10",
 
     **manpages_args
 )

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,17 @@ from datetime import date
 from distutils.command.build import build
 from typing import List
 
-from pkg_resources.extern.packaging.version import Version
+
+class Version(tuple):
+    def __new__(self, major, minor, patch):
+        return tuple.__new__(Version, (major, minor, patch))
+
+    def __str__(self):
+        return ".".join(map(str, self))
+
 
 # a version must be PEP 440 compliant
-__version__ = Version("1.0.0")
+__version__ = Version(1, 0, 0)
 
 
 def requirements(filename: str) -> List[str]:
@@ -32,8 +39,7 @@ def requirements(filename: str) -> List[str]:
 try:
     from setuptools import Command, Distribution, setup
 except ImportError:
-    print("setuptools unavailable, falling back to distutils.",
-          file=sys.stderr)
+    print("setuptools unavailable, falling back to distutils.", file=sys.stderr)
     from distutils.core import Command, Distribution, setup
 
 
@@ -125,6 +131,7 @@ setup(
     name="rgain3",
     version=str(__version__),
     description="Multi-format Replay Gain utilities",
+    readme="README.md",
     author="Felix Krull",
     author_email="f_krull@gmx.de",
     maintainer="Christian Haudum",
@@ -138,15 +145,18 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License (GPL)",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Multimedia :: Sound/Audio :: Analysis",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     long_description=__doc__,
-    packages=["rgain3"],
+    packages=["rgain3", "rgain3.lib"],
     console_entrypoints={
     },
     entry_points={
@@ -159,7 +169,7 @@ setup(
     extras_require={
         "test": ["tox>=3.14,<4.0"] + requirements("test-requirements.txt")
     },
-    python_requires=">=3.5",
+    python_requires=">=3.8",
 
     **manpages_args
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest>=5.3,<6.0
+pytest
 pytest-cov>=2.8
 pytest-flake8>=1.0
 pytest-isort>=0.3


### PR DESCRIPTION
`pkg_resources` have been removed from setuptools 82.0 and been superseded by the standard library `importlib.resources` and `importlib.metadata` packages`.

`importlib.metadata` has been added in Python 3.8, therefore the changed minimum required version.

Fixes #56 and #57 