### PR TITLE
chore(ci): Add Github workflow for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+---
+name: Publish
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+env:
+  PYTHON_VERSION: 3.14
+
+jobs:
+  publish:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rgain3
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+              gir1.2-gstreamer-1.0 \
+              gstreamer1.0-plugins-base \
+              gstreamer1.0-plugins-good \
+              gstreamer1.0-plugins-bad \
+              gstreamer1.0-plugins-ugly \
+              libcairo2-dev \
+              libgirepository-2.0-dev
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools docutils build
+          python -m pip install -e ".[test]"
+      - name: Run tests
+        run: |
+          python -m pytest
+      - name: Build distributions
+        run: |
+          python -m build --no-isolation --skip-dependency-check
+      - name: Publish to PyPi
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The workflow runs tests before building source and binary distributions using the `build` package. It is triggered by pushing tags that represent a semver string, e.g. `1.2.3`.

The upload to PyPi is authenticated and authorized by a "Trusted Publisher" https://docs.pypi.org/trusted-publishers/